### PR TITLE
add dynamic import() in eval() example

### DIFF
--- a/examples/dynamic-import-in-eval/README.md
+++ b/examples/dynamic-import-in-eval/README.md
@@ -1,0 +1,6 @@
+# dynamic-import-in-eval
+
+This example requires at least Node v12.10.0.
+
+* Run `npm i` or `yarn`
+* Run `npm test` or `yarn test`

--- a/examples/dynamic-import-in-eval/index.js
+++ b/examples/dynamic-import-in-eval/index.js
@@ -1,0 +1,9 @@
+eval(`(async () => {
+  const { default:_ } = await import <!--
+  (
+    //
+    'https://unpkg.com/lodash-es@4.17.15/lodash.js'
+    /**/
+  )
+  console.log(_.VERSION)
+})()`)

--- a/examples/dynamic-import-in-eval/loader.js
+++ b/examples/dynamic-import-in-eval/loader.js
@@ -1,0 +1,58 @@
+import { pathToFileURL } from 'url'
+import Module from 'module'
+import https from 'https'
+import process from 'process'
+import { promisify } from 'util'
+
+https.get[promisify.custom] = (options) => {
+  return new Promise((resolve, reject) => {
+    https.get(options, (response) => {
+      const { statusCode } = response
+
+      if (statusCode !== 200) {
+        reject(new Error(`Request Failed. Status code: ${statusCode}`))
+        return
+      }
+    
+      let raw = ''
+
+      response
+        .setEncoding('utf8')
+        .on('data', (chunk) => { raw += chunk })
+        .on('end', () => { resolve(raw) })
+    }).on('error', reject)
+  })
+}
+
+const baseURL = pathToFileURL(process.cwd()).href
+const { builtinModules } = Module
+const get = promisify(https.get)
+const dataToFileURLMap = new Map
+
+export async function resolve(specifier, parentModuleURL = baseURL, defaultResolver) {
+  if (builtinModules.includes(specifier)) {
+    return defaultResolver(specifier, parentModuleURL)
+  }
+
+  if (dataToFileURLMap.has(parentModuleURL)) {
+    parentModuleURL = dataToFileURLMap.get(parentModuleURL)
+  }
+
+  try {
+    const url = new URL(specifier, parentModuleURL)
+
+    if (url.protocol === 'https:') {
+      const body = await get(url)
+      const dataURI = `data:'text/javascript';base64,${Buffer.from(body).toString('base64')}`
+
+      dataToFileURLMap.set(dataURI, url.href)
+
+      return {
+        url: dataURI,
+        format: 'module'
+      }
+    }
+  } catch {}
+
+  return defaultResolver(specifier, parentModuleURL)
+}

--- a/examples/dynamic-import-in-eval/package.json
+++ b/examples/dynamic-import-in-eval/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "dynamic-import-in-eval",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "node --experimental-modules --es-module-specifier-resolution=node --experimental-loader ./loader.js ./"
+  }
+}


### PR DESCRIPTION
This PR adds a test case demonstrating a rogue `eval` call that then uses dynamic `import` to load a third party script. This is something that can be executed in a browser or in experimental Node with a loader (included in the PR).