### PR TITLE
Simplify loader and make more broadly applicable

### DIFF
--- a/examples/dynamic-import-in-eval/loader.js
+++ b/examples/dynamic-import-in-eval/loader.js
@@ -1,58 +1,54 @@
-import { pathToFileURL } from 'url'
-import Module from 'module'
+import { builtinModules } from 'module'
+import { extname } from 'path'
 import https from 'https'
-import process from 'process'
-import { promisify } from 'util'
 
-https.get[promisify.custom] = (options) => {
+const JS_MEDIA_TYPE = 'text/javascript'
+const dataToFileURLMap = new Map
+const extToMediaTypeMap = new Map([
+  ['.js', JS_MEDIA_TYPE],
+  ['.json', 'application/json'],
+  ['.mjs', JS_MEDIA_TYPE],
+  ['.wasm', 'application/wasm']
+])
+
+const get = (options) => {
   return new Promise((resolve, reject) => {
-    https.get(options, (response) => {
-      const { statusCode } = response
+    https
+      .get(options, (response) => {
+        const { statusCode } = response
 
-      if (statusCode !== 200) {
-        reject(new Error(`Request Failed. Status code: ${statusCode}`))
-        return
-      }
-    
-      let raw = ''
+        if (statusCode === 200) {
+          let body = ''
 
-      response
-        .setEncoding('utf8')
-        .on('data', (chunk) => { raw += chunk })
-        .on('end', () => { resolve(raw) })
-    }).on('error', reject)
+          response
+            .setEncoding('utf8')
+            .on('data', (chunk) => { body += chunk })
+            .on('end', () => { resolve(body) })
+        } else {
+          reject(new Error(`Request failed. Status code: ${statusCode}`))
+        }
+      })
+      .on('error', reject)
   })
 }
 
-const baseURL = pathToFileURL(process.cwd()).href
-const { builtinModules } = Module
-const get = promisify(https.get)
-const dataToFileURLMap = new Map
+export async function resolve(specifier, parentModuleURL, defaultResolver) {
+  if (! builtinModules.includes(specifier)) {
+    parentModuleURL = dataToFileURLMap.get(parentModuleURL) || parentModuleURL
 
-export async function resolve(specifier, parentModuleURL = baseURL, defaultResolver) {
-  if (builtinModules.includes(specifier)) {
-    return defaultResolver(specifier, parentModuleURL)
-  }
+    try {
+      const url = new URL(specifier, parentModuleURL)
 
-  if (dataToFileURLMap.has(parentModuleURL)) {
-    parentModuleURL = dataToFileURLMap.get(parentModuleURL)
-  }
+      if (url.protocol === 'https:') {
+        const body = await get(url)
+        const encoded = Buffer.from(body).toString('base64')
+        const mediaType = extToMediaTypeMap.get(extname(url.pathname)) || JS_MEDIA_TYPE
 
-  try {
-    const url = new URL(specifier, parentModuleURL)
-
-    if (url.protocol === 'https:') {
-      const body = await get(url)
-      const dataURI = `data:'text/javascript';base64,${Buffer.from(body).toString('base64')}`
-
-      dataToFileURLMap.set(dataURI, url.href)
-
-      return {
-        url: dataURI,
-        format: 'module'
+        specifier = `data:${mediaType};base64,${encoded}`
+        dataToFileURLMap.set(specifier, url.href)
       }
-    }
-  } catch {}
+    } catch {}
+  }
 
   return defaultResolver(specifier, parentModuleURL)
 }


### PR DESCRIPTION
I had some fun this evening simplifying the loader and making it more broadly applicable. We could use this to load in remote wasm files too.